### PR TITLE
Use Systemd

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'rvankleeck@salesforce.com'
 license 'BSD-3-Clause'
 description 'Installs/Configures jenkins swarm on a node'
 long_description 'Installs/Configures jenkins swarm on a node'
-version '1.1.9'
+version '1.2.0'
 chef_version '>= 12.6' if respond_to?(:chef_version)
 supports 'centos'
 supports 'windows'

--- a/recipes/linux.rb
+++ b/recipes/linux.rb
@@ -1,5 +1,7 @@
 fsroot = node['jenkins_swarm']['parameters']['fsroot'].to_s
 service_user = node['jenkins_swarm']['client']['service_user'].to_s
+jenkins_keys = data_bag_item('jenkins', 'keys')
+
 
 directory "#{fsroot}/.ssh" do
   mode 0700
@@ -14,6 +16,28 @@ cookbook_file "#{fsroot}/.ssh/config" do
   mode 00644
 end
 
+if node['jenkins_swarm']['client']['service_user_ssh_keys']
+  node.run_state['private_key'] = jenkins_keys[service_user]['private'].to_s
+  node.run_state['public_key'] = jenkins_keys[service_user]['public'].to_s
+
+  file "#{fsroot}/.ssh/id_rsa" do
+    content node.run_state['private_key']
+    mode 0600
+    owner service_user
+    group service_user
+    sensitive true
+  end
+
+  file "#{fsroot}/.ssh/id_rsa.pub" do
+    content node.run_state['public_key']
+    mode 0644
+    owner service_user
+    group service_user
+    sensitive true
+  end
+end
+
+
 # Creates a file that is only readable by root to store the password to login to Jenkins
 template "#{fsroot}/.secret" do
   source 'secret.erb'
@@ -24,10 +48,9 @@ template "#{fsroot}/.secret" do
   sensitive true
 end
 
-template '/etc/init.d/swarm' do
-  source 'swarm_service.sh.erb'
+template '/etc/systemd/system/swarm.service' do
+  source 'swarm.service.erb'
   mode 0755
-  variables(java_cmd: node['jenkins_swarm']['client']['java_cmd'])
   notifies :run, 'bash[reload_daemons]', :immediate
 end
 
@@ -40,6 +63,7 @@ bash 'reload_daemons' do
 end
 
 service 'swarm' do
-  init_command '/etc/init.d/swarm'
+  # init_command '/etc/init.d/swarm'
+  # status_command '/etc/init.d/swarm status'
   action [:enable, :start]
 end

--- a/templates/swarm.service.erb
+++ b/templates/swarm.service.erb
@@ -1,0 +1,13 @@
+[Unit]
+Description=Jenkins Slave from Swarm
+Wants=network.target
+After=network.target
+
+[Service]
+EnvironmentFile=/opt/jenkins/.secret
+ExecStart=/usr/bin/<%= node['jenkins_swarm']['client']['java_cmd'] %>
+ExecStop=/usr/bin/pkill -f '<%= node['jenkins_swarm']['client']['java_cmd'] %>'
+User=<%= node['jenkins_swarm']['client']['service_user'] %>
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Uses systemd instead of init.d for the swarm service. This has been shown to make restarting the service more accurate if anything changes in the service itself.